### PR TITLE
Fix accordion and toggle keyboard double-triggering on keyup

### DIFF
--- a/public/js/fix-divi-tabs-accordions-toggles.js
+++ b/public/js/fix-divi-tabs-accordions-toggles.js
@@ -200,11 +200,11 @@ jQuery(document).ready(function($) {
 	});
 	
 	/* control with enter or space */
-	$('.et_pb_accordion_item .et_pb_toggle_title button').on('keyup', function(n){
+	$('.et_pb_accordion_item .et_pb_toggle_title button').on('keydown', function(n){
 		if(n.keyCode==13 || n.keyCode==32){ //enter and space bar
 			n.preventDefault();
 			n.stopPropagation();
-			$(this).trigger('click');
+			this.click();
 		}
 	});	
 	
@@ -223,11 +223,11 @@ jQuery(document).ready(function($) {
 	});
 	
 	/* control with enter or space */
-	$('.et_pb_toggle_item .et_pb_toggle_title button').on('keyup', function(n){
+	$('.et_pb_toggle_item .et_pb_toggle_title button').on('keydown', function(n){
 		if(n.keyCode==13 || n.keyCode==32){ //enter and space bar
 			n.preventDefault();
 			n.stopPropagation();
-			$(this).trigger('click');
+			this.click();
 		}
 	});	
 });

--- a/public/js/fix-divi-tabs-accordions-toggles.js
+++ b/public/js/fix-divi-tabs-accordions-toggles.js
@@ -203,6 +203,7 @@ jQuery(document).ready(function($) {
 	$('.et_pb_accordion_item .et_pb_toggle_title button').on('keyup', function(n){
 		if(n.keyCode==13 || n.keyCode==32){ //enter and space bar
 			n.preventDefault();
+			n.stopPropagation();
 			$(this).trigger('click');
 		}
 	});	
@@ -224,6 +225,8 @@ jQuery(document).ready(function($) {
 	/* control with enter or space */
 	$('.et_pb_toggle_item .et_pb_toggle_title button').on('keyup', function(n){
 		if(n.keyCode==13 || n.keyCode==32){ //enter and space bar
+			n.preventDefault();
+			n.stopPropagation();
 			$(this).trigger('click');
 		}
 	});	


### PR DESCRIPTION
Fixes an issue where accordion and standalone toggle items would trigger twice (closing and immediately reopening) when a user activates them via the keyboard (using the Enter or Space keys).

This happens because the browser fires a native click event in addition to the custom keyup handler on button elements. Adding n.preventDefault() and n.stopPropagation() to the keyup event listeners ensures that the event is handled cleanly without bubbling up and triggering Divi's internal toggles a second time.