### PR TITLE
Remove aria-expanded from tab elements

### DIFF
--- a/public/js/fix-divi-tabs-accordions-toggles.js
+++ b/public/js/fix-divi-tabs-accordions-toggles.js
@@ -23,15 +23,13 @@ jQuery(document).ready(function($) {
 	$('.et_pb_tabs_controls li.et_pb_tab_active a').each(function () {
 		$(this).attr({
 			'aria-selected': 'true',
-			'aria-expanded': 'true',
 			tabindex: 0
 		});
 	});
-	
+
 	$('.et_pb_tabs_controls li:not(.et_pb_tab_active) a').each(function () {
 		$(this).attr({
 			'aria-selected': 'false',
-			'aria-expanded': 'false',
 			tabindex: -1
 		});
 	});
@@ -69,13 +67,11 @@ jQuery(document).ready(function($) {
 		
 		$('[id="' + tabsId + '"] .et_pb_tabs_controls a').attr({
 			'aria-selected': 'false',
-			'aria-expanded': 'false',
 			tabindex: -1
 		});
-		
+
 		$(this).attr({
 			'aria-selected': 'true',
-			'aria-expanded': 'true',
 			tabindex: 0
 		});
 		


### PR DESCRIPTION
## Summary

ARIA conformance improvement for the Tabs component. Aligns the implementation with the [WAI-ARIA Authoring Practices – Tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/). Does not change functionality.

`role="tab"` elements were setting both `aria-selected` and `aria-expanded`. Per the APG, `aria-selected` is the correct state attribute for tabs in a single-select tab interface; `aria-expanded` is scoped to disclosure widgets (accordions, toggles), where it communicates whether a control's associated content region is currently shown or hidden. Applying both to a tab is redundant and not part of the tab role's spec.

## Changes

In `public/js/fix-divi-tabs-accordions-toggles.js`, Tabs section only:

- Removed `aria-expanded` from the active-tab initialization handler.
- Removed `aria-expanded` from the inactive-tabs initialization handler.
- Removed `aria-expanded` from both branches of the tab click handler.
- `aria-selected="true"`/`aria-selected="false"` behavior is unchanged.

The Accordion and Toggle sections of this file are untouched — `aria-expanded` remains there, which is correct for those disclosure patterns.

## Not changed

- `aria-controls`, `aria-labelledby`, `aria-hidden`, and `tabindex` behavior on tabs/panels.
- Left/right arrow key navigation.
- Click handling and focus management.
- Accordion and toggle ARIA implementations.

## Test plan

- [ ] Active tab has `aria-selected="true"` and no `aria-expanded`; inactive tabs have `aria-selected="false"` and no `aria-expanded`.
- [ ] Clicking a tab toggles `aria-selected` correctly, updates the panel's `aria-hidden`/`tabindex`, and no `aria-expanded` appears on any tab.
- [ ] Left/right arrow keys navigate between tabs with correct wraparound and focus movement.
- [ ] Accordion and Toggle modules still use `aria-expanded` as before (unaffected).